### PR TITLE
Patch: rename Typus::Orm::Base.adapter method due to the method name conflict with the Rolify gem

### DIFF
--- a/lib/typus/orm/active_record/search.rb
+++ b/lib/typus/orm/active_record/search.rb
@@ -20,7 +20,10 @@ module Typus
                        end
 
               column_name = (key.match('\.') ? key : "#{table_name}.#{key}")
-              table_key = (adapter == 'postgresql') ? "LOWER(TEXT(#{column_name}))" : "#{column_name}"
+              # 2016/7/6 by t.o.
+              # adapter メソッドのメソッド名変更パッチに対応( adapter -> rf_typus_adapter)
+              #table_key = (adapter == 'postgresql') ? "LOWER(TEXT(#{column_name}))" : "#{column_name}"
+              table_key = (rf_typus_adapter == 'postgresql') ? "LOWER(TEXT(#{column_name}))" : "#{column_name}"
 
               search << "#{table_key} LIKE '#{_query}'"
             end

--- a/lib/typus/orm/base/class_methods.rb
+++ b/lib/typus/orm/base/class_methods.rb
@@ -145,8 +145,13 @@ module Typus
           end
         end
 
-        def adapter
-          @adapter ||= ::ActiveRecord::Base.connection_config[:adapter]
+        # 2016/7/6 by t.o.
+        # Rolify gem の同名メソッドとの名前衝突回避のためメソッド名を変更する（adapter -> rf_typus_adapter)
+        #def adapter
+        #  @adapter ||= ::ActiveRecord::Base.connection_config[:adapter]
+        #end
+        def rf_typus_adapter
+          @rf_typus_adapter ||= ::ActiveRecord::Base.connection_config[:adapter]
         end
 
         def typus_user_id?; end


### PR DESCRIPTION
`adapter` メソッドが Rolify gem の同名メソッドと衝突するのでメソッド名変更（及び呼び出し元のコード変更）で対応。
`adapter` -> `rf_typus_adapter` 
